### PR TITLE
open urls in new window

### DIFF
--- a/modules/Router.js
+++ b/modules/Router.js
@@ -21,6 +21,8 @@ export class Router {
 
   handleElementDoubleClick = (event, elementId) => {
     const element = structurizr.workspace.findElementById(elementId)
+    
+    if(element.url) window.open(element.url, '_blank');
 
     switch (element.type) {
       case structurizr.constants.SOFTWARE_SYSTEM_ELEMENT_TYPE:


### PR DESCRIPTION
quick change to update Router.js so that double-clicking an element with a url will open the url in a new window.