### PR TITLE
Add corrected namespace for `GraphvizAutomaticLayout`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ As a static site without a server runtime, Mini can't do that. Luckily there's a
 ```
 workspace extends workspace.json {
   !script groovy {
-    new com.structurizr.graphviz.GraphvizAutomaticLayout().apply(workspace);
+    new com.structurizr.autolayout.graphviz.GraphvizAutomaticLayout().apply(workspace);
   }
 }
 ```


### PR DESCRIPTION
As of https://github.com/structurizr/lite/commit/ffcdf97d2ac5de2f1e48a403d2aa32d85d88d1fe the namespace got extended by `autolayout`